### PR TITLE
Correção em constante para envio de PIX.

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -243,7 +243,7 @@ module.exports = {
 					method: 'get',
 				},
 				pixSend: {
-					route: '/v2/pix/:idEnvio',
+					route: '/v2/gn/pix/:idEnvio',
 					method: 'put',
 				},
 				pixSendDetail: {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "gn-api-sdk-node",
 	"description": "Module for integration with Gerencianet API",
-	"version": "3.0.2",
+	"version": "3.0.3",
 	"author": "Gerencianet - Consultoria Tecnica | Palloma Brito | João Vitor Oliveira",
 	"license": "MIT",
 	"repository": "gerencianet/gn-api-sdk-node",


### PR DESCRIPTION
Existe uma constante mapeada de forma incorreta, ao tentar utilizar o método `pixSend` o erro `{ nome: 'nao_encontrado', mensagem: 'Recurso não encontrado' }` é retornado.

Com a correção, o método estará correto.